### PR TITLE
[Fix] - replace id room with name room

### DIFF
--- a/src/components/DispensationControls/NewDispForm.tsx
+++ b/src/components/DispensationControls/NewDispForm.tsx
@@ -60,7 +60,7 @@ export default function NewDispForm() {
 						setRoomData(
 							results.data.rooms.map((d: any) => ({
 								label: d.name ? d.name : '',
-								value: d.id,
+								value: d.name,
 							}))
 						);
 					}
@@ -94,7 +94,7 @@ export default function NewDispForm() {
 		data.endDate = data.endDate.format('YYYY-MM-DD');
 		data.rooms =
 			data.rooms.length > 0
-				? `[${data.rooms.map(r => `{ id: ${r.value} }`).join(', ')}]`
+				? `[${data.rooms.map(r => `{ name: "${r.value}" }`).join(', ')}]`
 				: null;
 		data.holders =
 			data.holders.length > 0

--- a/src/components/DispensationControls/UpdateDispForm.tsx
+++ b/src/components/DispensationControls/UpdateDispForm.tsx
@@ -85,7 +85,7 @@ export default function UpdateDispForm() {
 						setRoomData(
 							resultsDetails.data.rooms.map((d: any) => ({
 								label: d.name ? d.name : '',
-								value: d.id,
+								value: d.name,
 							}))
 						);
 						if (urlParams.get('slug')) {
@@ -147,7 +147,7 @@ export default function UpdateDispForm() {
 				.map(e => holderData.find((o: any) => o.value === e)));
 		data.rooms =
 			data.rooms.length > 0
-				? `[${data.rooms.map(r => `{ id: ${r.value} }`).join(', ')}]`
+				? `[${data.rooms.map(r => `{ name: "${r.value}" }`).join(', ')}]`
 				: null;
 		data.holders =
 			data.holders.length > 0
@@ -175,7 +175,7 @@ export default function UpdateDispForm() {
 						setValue('endDate', dayjs(res.data.date_end));
 						setValue('requirements', res.data.description);
 						setValue('comment', res.data.comment);
-						setValue('rooms', res.data.rooms.map((d: any) => d.id).join(','));
+						setValue('rooms', res.data.rooms.map((d: any) => d.name).join(','));
 						setValue(
 							'holders',
 							res.data.holders.map((d: any) => d.sciper).join(',')
@@ -295,7 +295,7 @@ export default function UpdateDispForm() {
 												? value
 														.split(',')
 														.map(e =>
-															roomData.find((o: any) => o.value === parseInt(e))
+															roomData.find((o: any) => o.value === e)
 														)
 												: value || []
 										}


### PR DESCRIPTION
The ID of the room was accessible on GraphQL queries. It has been replaced with the name (**lab_display**) of the room in order to use its identifier common to the entire School information system.